### PR TITLE
bugfix windowed Z computation for shapeMethod=D

### DIFF
--- a/src/ViennaRNA/LPfold.c
+++ b/src/ViennaRNA/LPfold.c
@@ -1816,7 +1816,8 @@ compute_pU(vrna_fold_compound_t       *vc,
    */
   for (startu = MIN2(ulength, k); startu > 0; startu--) {
     temp = 0.;
-    if (sc) {
+    // check whether soft constraint unpaired contributions available
+    if (sc && sc->exp_energy_up) {
       if (hc->up_ext[k - startu + 1] >= startu) {
         for (i5 = MAX2(1, k - winSize + 2); i5 <= MIN2(k - startu, n - winSize + 1); i5++)
           temp += q[i5][k - startu] *


### PR DESCRIPTION
was not checking in line 1819 whether unpaired contributions are available, which is not the case for shapeMethod=D