### PR TITLE
VRNA_VERSION define as string

### DIFF
--- a/src/ViennaRNA/vrna_config.h.in
+++ b/src/ViennaRNA/vrna_config.h.in
@@ -2,7 +2,7 @@
 #define VIENNA_RNA_PACKAGE_CONFIG_H
 
 /* version number */
-#define VRNA_VERSION  @VERSION@
+#define VRNA_VERSION  "@VERSION@"
 
 /*
  * The following pre-processor definitions specify whether


### PR DESCRIPTION
this enables a direct output of the VRNA_VERSION macro e.g. in C++ contet via std::cout <<VRNA_VERSION, which otherwise results in the compilation error
```
error: too many decimal points in number
 #define VRNA_VERSION  2.4.4
                       ^
CommandLineParsing.cpp:697:45: note: in expansion of macro 'VRNA_VERSION'
    std::cout <<"using Vienna RNA package "<<VRNA_VERSION << "\n";
                                             ^
```

## Alternative:

I am using the following defines as a [workaround](https://stackoverflow.com/questions/12844117/printing-defined-constants)
```[c++]
#define _STRINGIFY(s) #s
#define STRINGIFY(s) _STRINGIFY(s)

std::cout <<STRINGIFY(VRNA_VERSION);
```
but I am not sure if this is really the intended way to use the VRNA_VERSION macro.. ?!