### PR TITLE
Fix compilation of RNAforester

### DIFF
--- a/src/RNAforester/src/frontend/Arguments.cpp
+++ b/src/RNAforester/src/frontend/Arguments.cpp
@@ -28,8 +28,7 @@ std::vector<std::string> Arguments::s_spaceArgs;
 //   Explodes a string into tokens, which it adds to a vector.
 //   (This function is taken from the AFA library, also by Jared Davis)
 //
-void Arguments::ExplodeString(const std::string& str, std::vector<std::string>& tokens, char delimiter)
-throw(std::bad_alloc) {
+void Arguments::ExplodeString(const std::string& str, std::vector<std::string>& tokens, char delimiter) {
     std::string::size_type next, prev = 0;
 
     do {
@@ -89,14 +88,13 @@ int Arguments::findArgument(const std::string& arg) const throw() {
 //   spaces vector.  keeps the vector sorted.
 //
 #include <iostream>
-void Arguments::setArgumentsWithSpaces(const std::string& args)
-throw(std::bad_alloc) {
+void Arguments::setArgumentsWithSpaces(const std::string& args) {
     ExplodeString(args, s_spaceArgs, '|');
     std::sort(s_spaceArgs.begin(), s_spaceArgs.end());
 }
 
 
-Arguments::Arguments(int argc, const char** argv) throw(std::bad_alloc) {
+Arguments::Arguments(int argc, const char** argv) {
     // start at 1 to skip program's name.
     for (int i = 1; i < argc; ++i) {
         // Extract this token.
@@ -169,7 +167,7 @@ unsigned int Arguments::size() const throw() {
 //   Cycle through the tokens of argument and return true if any of them
 //   are found.
 //
-bool Arguments::has(const std::string& argument) const throw(std::bad_alloc) {
+bool Arguments::has(const std::string& argument) const {
     return findArgument(argument) != -1;
 }
 

--- a/src/RNAforester/src/frontend/Arguments.h
+++ b/src/RNAforester/src/frontend/Arguments.h
@@ -45,8 +45,7 @@ private:
 
 
     // explodes a delimited string into its tokens.
-    static void ExplodeString(const std::string& str, std::vector<std::string>& tokens, char delimiter)
-    throw(std::bad_alloc);
+    static void ExplodeString(const std::string& str, std::vector<std::string>& tokens, char delimiter);
 
     // finds the index of the argument arg.
     int findArgument(const std::string& arg) const throw();
@@ -68,19 +67,16 @@ private:
 
 public:
 
-    static void setArgumentsWithSpaces(const std::string& args)
-    throw(std::bad_alloc);
+    static void setArgumentsWithSpaces(const std::string& args);
 
-    Arguments(int argc, const char** argv)
-    throw(std::bad_alloc);
+    Arguments(int argc, const char** argv);
 
     unsigned int size() const throw();
 
-    bool has(const std::string& arg) const throw(std::bad_alloc);
+    bool has(const std::string& arg) const;
 
     template<class A, class B> bool get
-    (const std::string& arg, A& value, const B& default_value) const
-    throw(std::bad_alloc) {
+    (const std::string& arg, A& value, const B& default_value) const {
         int index = findArgument(arg);
 
         if (index == -1) {

--- a/src/RNAforester/src/main.cpp
+++ b/src/RNAforester/src/main.cpp
@@ -495,7 +495,7 @@ int main(int argc, const char **argv) {
         e.showError();
         return(EXIT_FAILURE);
     }
-		catch (std::bad_alloc e) {
+		catch (const std::bad_alloc &e) {
 				std::cout << "Alignment computation aborted, out of memory." << std::endl;
         return(EXIT_FAILURE);
 		}


### PR DESCRIPTION
 - RNAforester used dynamic exception specification, which are
   depracted since C++11 and invalid since C++17.
   Such specs were simply removed.
 - fix catch of polymorphic exception by value (should be by ref),
   which caused a warning, but did not have other consequences