### PR TITLE
Fix RNAFold pre-built windows binary

### DIFF
--- a/packaging/win_installer_archlinux_x86_64.nsi.in
+++ b/packaging/win_installer_archlinux_x86_64.nsi.in
@@ -124,6 +124,7 @@ section "Core" sec_core
   File "/usr/x86_64-w64-mingw32/bin/libmpfr-6.dll"
   File "/usr/x86_64-w64-mingw32/bin/libgmp-10.dll"
   File "/usr/x86_64-w64-mingw32/bin/libgmpxx-4.dll"
+  File "/usr/x86_64-w64-mingw32/bin/libssp-0.dll"
 
   File ".local"
 
@@ -244,6 +245,7 @@ section "Uninstall"
   delete $INSTDIR\libmpfr-6.dll
   delete $INSTDIR\libgmp-10.dll
   delete $INSTDIR\libgmpxx-4.dll
+  delete $INSTDIR\libssp-0.dll
   delete $INSTDIR\.local
 
   delete "$INSTDIR\Uninstall-${PACKAGE}.exe"


### PR DESCRIPTION
When I download and install

https://www.tbi.univie.ac.at/RNA/download/win/windows/Install-ViennaRNA-2.4.16_64bit.exe

and run RNAFold.exe, I get an error that libssp-0.dll is missing

I believe this would fix that.