### PR TITLE
Restore Functionality of RNAPKplex

### DIFF
--- a/src/ViennaRNA/plex_functions.c
+++ b/src/ViennaRNA/plex_functions.c
@@ -377,7 +377,7 @@ update_dfold_params(void)
   if (P)
     free(P);
 
-  set_model_details(&md);
+  vrna_md_set_default(&md);
   P = vrna_params(&md);
   make_pair_matrix();
 }

--- a/src/bin/RNAPKplex.c
+++ b/src/bin/RNAPKplex.c
@@ -270,6 +270,11 @@ main(int  argc,
       PlexHits[NumberOfHits].structure  = NULL;
       NumberOfHits++;
 
+      for (i = 0; i < NumberOfHits; i++) {
+        PlexHits[i].inactive = 0;
+        PlexHits[i].processed = 0;
+      }
+
       /* first sort all the pre-results descending by their estimated energy */
       qsort(PlexHits, NumberOfHits, sizeof(dupVar), PlexHit_cmp);
 

--- a/src/bin/RNAPKplex.c
+++ b/src/bin/RNAPKplex.c
@@ -350,11 +350,7 @@ main(int  argc,
             if (!PlexHits[i].inactive) {
               if (PlexHits[i].structure) {
                 if (!PlexHits[i].processed) {
-                  double cost = PlexHits[i].dG1;
-                  if (PlexHits[i].dG2 > cost)
-                    cost = PlexHits[i].dG2;
-
-                  cost += mfe + PlexHits[i].ddG + pk_penalty;
+                  double cost = mfe + PlexHits[i].ddG + pk_penalty;
                   if (cost > mfe + subopts)
                     PlexHits[i].inactive = 1;
                 } else {

--- a/src/bin/RNAPKplex.c
+++ b/src/bin/RNAPKplex.c
@@ -287,7 +287,8 @@ main(int  argc,
       constraint  = (char *)vrna_alloc(sizeof(char) * (length + 1));
       mfe_struct  = (char *)vrna_alloc(sizeof(char) * (length + 1));
 
-      mfe = mfe_pk = fold_par(s1, mfe_struct, par, 0, 0);
+      vrna_fold_compound_t *fc = vrna_fold_compound (s1, &md, VRNA_OPTION_MFE);
+      mfe = mfe_pk = vrna_mfe(fc, mfe_struct);
       /*      if(verbose)
        *        printf("%s (%6.2f) [mfe-pkfree]\n", mfe_struct, mfe);
        */
@@ -305,7 +306,9 @@ main(int  argc,
             constraint[length] = '\0';
 
             /* energy evaluation */
-            constrainedEnergy = fold_par(s1, constraint, par, 1, 0);
+            vrna_hc_init(fc);
+            vrna_hc_add_from_db (fc, constraint, VRNA_CONSTRAINT_DB_X);
+            constrainedEnergy = vrna_mfe(fc, constraint);
 
             /* check if this structure is worth keeping */
             if (constrainedEnergy + PlexHits[current].ddG + pk_penalty <= mfe_pk + subopts) {
@@ -363,6 +366,7 @@ main(int  argc,
       }
       constraint = NULL;
       free(par);
+      vrna_fold_compound_free(fc);
 
       /* now sort the actual results again according to their energy */
 

--- a/src/bin/RNAPKplex.c
+++ b/src/bin/RNAPKplex.c
@@ -322,7 +322,7 @@ main(int  argc,
                 if (PlexHits[current].structure[i - PlexHits[current].qb + 1 + 1 + 1 + PlexHits[current].te - PlexHits[current].tb] == ')')
                   constraint[i] = ']';
 
-              PlexHits[current].energy = constrainedEnergy + PlexHits[current].ddG + (float)pk_penalty + PlexHits[current].dG1 + PlexHits[current].dG2;
+              PlexHits[current].energy = constrainedEnergy + PlexHits[current].ddG + pk_penalty;
               if (PlexHits[current].energy < mfe_pk)
                 mfe_pk = PlexHits[current].energy;
 

--- a/src/bin/RNAPKplex.c
+++ b/src/bin/RNAPKplex.c
@@ -53,7 +53,6 @@ main(int  argc,
   double                  **pup, subopts, pk_penalty;
   plist                   *pl, *dpp;
   vrna_md_t               md;
-  vrna_param_t            *par;
 
   options     = 0;
   pup         = NULL;           /*prob of being unpaired, lengthwise*/
@@ -70,10 +69,9 @@ main(int  argc,
   pk_penalty  = 8.10;
   ParamFile   = ns_bases = NULL;
   s1          = id_s1 = orig_s1 = NULL;
-  par         = NULL;
   annotation  = NULL;
 
-  set_model_details(&md);
+  vrna_md_set_default(&md);
 
   /*
    #############################################
@@ -201,7 +199,6 @@ main(int  argc,
      # do PLfold computations
      ########################################################
      */
-    update_fold_params();
     if (length >= 5) {
       pf_scale = -1;
 
@@ -283,7 +280,6 @@ main(int  argc,
       double  mfe_pk      = 0.;
       char    *mfe_struct = NULL;
 
-      par         = vrna_params(&md);
       constraint  = (char *)vrna_alloc(sizeof(char) * (length + 1));
       mfe_struct  = (char *)vrna_alloc(sizeof(char) * (length + 1));
 
@@ -365,7 +361,6 @@ main(int  argc,
         }
       }
       constraint = NULL;
-      free(par);
       vrna_fold_compound_free(fc);
 
       /* now sort the actual results again according to their energy */

--- a/src/bin/RNAPKplex.c
+++ b/src/bin/RNAPKplex.c
@@ -29,12 +29,14 @@
 #include "ViennaRNA/PKplex.h"
 #include "RNAPKplex_cmdl.h"
 
-int PlexHit_cmp(const void  *c1,
-                const void  *c2);
+int
+PlexHit_cmp(const void  *c1,
+            const void  *c2);
 
 
-int PlexHit_cmp_energy(const void *c1,
-                       const void *c2);
+int
+PlexHit_cmp_energy(const void *c1,
+                   const void *c2);
 
 
 /*--------------------------------------------------------------------------*/
@@ -139,7 +141,7 @@ main(int  argc,
    */
   if (ParamFile != NULL) {
     if (!strcmp(ParamFile, "DNA"))
-        vrna_params_load_DNA_Mathews2004();
+      vrna_params_load_DNA_Mathews2004();
     else
       vrna_params_load(ParamFile, VRNA_PARAMETER_FORMAT_DEFAULT);
   }
@@ -160,7 +162,8 @@ main(int  argc,
    # main loop: continue until end of file
    #############################################
    */
-  while (!(vrna_file_fasta_read_record(&id_s1, &s1, &rest, NULL, options) & (VRNA_INPUT_ERROR | VRNA_INPUT_QUIT))) {
+  while (!(vrna_file_fasta_read_record(&id_s1, &s1, &rest, NULL,
+                                       options) & (VRNA_INPUT_ERROR | VRNA_INPUT_QUIT))) {
     /*
      ########################################################
      # handle user input from 'stdin'
@@ -271,7 +274,7 @@ main(int  argc,
       NumberOfHits++;
 
       for (i = 0; i < NumberOfHits; i++) {
-        PlexHits[i].inactive = 0;
+        PlexHits[i].inactive  = 0;
         PlexHits[i].processed = 0;
       }
 
@@ -281,14 +284,14 @@ main(int  argc,
       /*  now we re-evaluate the energies and thereby prune the list of pre-results
        *  such that the re-avaluation process is not done too often.
        */
-      double  mfe         = 0.;
-      double  mfe_pk      = 0.;
-      char    *mfe_struct = NULL;
+      double                mfe         = 0.;
+      double                mfe_pk      = 0.;
+      char                  *mfe_struct = NULL;
 
       constraint  = (char *)vrna_alloc(sizeof(char) * (length + 1));
       mfe_struct  = (char *)vrna_alloc(sizeof(char) * (length + 1));
 
-      vrna_fold_compound_t *fc = vrna_fold_compound (s1, &md, VRNA_OPTION_MFE);
+      vrna_fold_compound_t  *fc = vrna_fold_compound(s1, &md, VRNA_OPTION_MFE);
       mfe = mfe_pk = vrna_mfe(fc, mfe_struct);
       /*      if(verbose)
        *        printf("%s (%6.2f) [mfe-pkfree]\n", mfe_struct, mfe);
@@ -308,7 +311,7 @@ main(int  argc,
 
             /* energy evaluation */
             vrna_hc_init(fc);
-            vrna_hc_add_from_db (fc, constraint, VRNA_CONSTRAINT_DB_X);
+            vrna_hc_add_from_db(fc, constraint, VRNA_CONSTRAINT_DB_X);
             constrainedEnergy = vrna_mfe(fc, constraint);
 
             /* check if this structure is worth keeping */
@@ -319,7 +322,8 @@ main(int  argc,
                   constraint[i] = '[';
 
               for (i = PlexHits[current].qb - 1; i < PlexHits[current].qe; i++)
-                if (PlexHits[current].structure[i - PlexHits[current].qb + 1 + 1 + 1 + PlexHits[current].te - PlexHits[current].tb] == ')')
+                if (PlexHits[current].structure[i - PlexHits[current].qb + 1 + 1 + 1 +
+                                                PlexHits[current].te - PlexHits[current].tb] == ')')
                   constraint[i] = ']';
 
               PlexHits[current].energy = constrainedEnergy + PlexHits[current].ddG + pk_penalty;
@@ -420,12 +424,23 @@ main(int  argc,
       if (verbose) {
         printf("\n");
         for (i = 0; i < NumberOfHits; i++)
-          printf("%d\t%s %3d,%-3d : %3d,%-3d (%5.2f = %5.2f + %5.2f + %5.2f)\n", PlexHits[i].inactive, PlexHits[i].structure, PlexHits[i].tb, PlexHits[i].te, PlexHits[i].qb, PlexHits[i].qe, PlexHits[i].ddG, PlexHits[i].energy, PlexHits[i].dG1, PlexHits[i].dG2);
+          printf("%d\t%s %3d,%-3d : %3d,%-3d (%5.2f = %5.2f + %5.2f + %5.2f)\n",
+                 PlexHits[i].inactive,
+                 PlexHits[i].structure,
+                 PlexHits[i].tb,
+                 PlexHits[i].te,
+                 PlexHits[i].qb,
+                 PlexHits[i].qe,
+                 PlexHits[i].ddG,
+                 PlexHits[i].energy,
+                 PlexHits[i].dG1,
+                 PlexHits[i].dG2);
       }
 
       current = -1;
 
-      while ((PlexHits[0].ddG + subopts >= PlexHits[current + 1].ddG) && (current + 1 < NumberOfHits)) {
+      while ((PlexHits[0].ddG + subopts >= PlexHits[current + 1].ddG) &&
+             (current + 1 < NumberOfHits)) {
         current++;
 
         /*
@@ -462,12 +477,15 @@ main(int  argc,
               constraint[i] = '[';
 
           for (i = PlexHits[current].qb - 1; i <= PlexHits[current].qe - 1; i++)
-            if (PlexHits[current].structure[i - PlexHits[current].qb + 1 + 1 + 1 + PlexHits[current].te - PlexHits[current].tb] == ')')
+            if (PlexHits[current].structure[i - PlexHits[current].qb + 1 + 1 + 1 +
+                                            PlexHits[current].te - PlexHits[current].tb] == ')')
               constraint[i] = ']';
         }
 
         if (PlexHits[current].structure)
-          printf("%s   (%3.2f)\n", constraint, constrainedEnergy + PlexHits[current].ddG - (float)pk_penalty);
+          printf("%s   (%3.2f)\n",
+                 constraint,
+                 constrainedEnergy + PlexHits[current].ddG - (float)pk_penalty);
         else
           printf("%s   (%3.2f)\n", constraint, constrainedEnergy + PlexHits[current].ddG);
 
@@ -489,7 +507,8 @@ main(int  argc,
               if ((stem) && (PlexHits[current].structure[i] != '(')) {
                 end   = i - 1;
                 stem  = 0;
-                sprintf(temp, "%d %d 13 1 0 0 omark\n", (int)PlexHits[current].tb + start, PlexHits[current].tb + end);
+                sprintf(temp, "%d %d 13 1 0 0 omark\n", (int)PlexHits[current].tb + start,
+                        PlexHits[current].tb + end);
                 strcat(annotation, temp);
               }
 
@@ -504,7 +523,11 @@ main(int  argc,
               if ((stem) && (PlexHits[current].structure[i] != ')')) {
                 end   = i - 1;
                 stem  = 0;
-                sprintf(temp, "%d %d 13 1 0 0 omark\n", PlexHits[current].qb + start - PlexHits[current].te + PlexHits[current].tb - 2, PlexHits[current].qb + end - PlexHits[current].te + PlexHits[current].tb - 2);
+                sprintf(temp,
+                        "%d %d 13 1 0 0 omark\n",
+                        PlexHits[current].qb + start - PlexHits[current].te + PlexHits[current].tb - 2,
+                        PlexHits[current].qb + end - PlexHits[current].te + PlexHits[current].tb -
+                        2);
                 strcat(annotation, temp);
               }
 
@@ -514,7 +537,10 @@ main(int  argc,
               }
             }
 
-            sprintf(temp, "0 0 2 setrgbcolor\n2 setlinewidth\n%d cmark\n%d cmark\n1 setlinewidth", PlexHits[current].tb, PlexHits[current].qe);
+            sprintf(temp,
+                    "0 0 2 setrgbcolor\n2 setlinewidth\n%d cmark\n%d cmark\n1 setlinewidth",
+                    PlexHits[current].tb,
+                    PlexHits[current].qe);
             strcat(annotation, temp);
             vrna_file_PS_rnaplot_a(s1, constraint, fname, annotation, "", &md);
             free(annotation);


### PR DESCRIPTION
This PR attempts to fix a few issues with `RNAPKplex`:

- 60b409b9782cb68b1857522496c94e9b36648dd1 restores general functionality since `fold_par` is deprecated and didn't produce any meaningful results.
- Other deprecated function calls got removed or replaced if deemed necessary.
- 0ecb7c285c687261815ff8e4f2007fd64849a403 fixes a now-arising issue where subsequently inputting the same sequence in a single run of `RNAPKplex` produces different results. This can be tested with the following sequence (and possibly a fictitious penalty `-e -8.1`):
```
GCCGUGUGCCUUGCGCCGGGAAACCACGCAAGGGAUGGUGUCAAAUUCGGCGAAACCUAAGCGCCCGCCCGGGCGUAUGGCAACGCCGAGCCAAGCUUCGCAGCCAUUGCACUCCGGCUGCGAUGAAGGUGUAGAGACUAGACGGCACCCACCUAAGGCAAACGCUAUGGUGAAGGCAUAGUCCAGGGAGUGGCGAAAGUCACACAAACCGG
```
- 1ce53dc1172be0fad019e71ed7f4f7f96f6fcfbc (+ 7a7e84ae8f6954dff43cc31d581b0bcc63b8a1e1) is probably the most controversial change. This removes the costs for making a region of the sequence accessible. In [the original algorithm](https://www.tbi.univie.ac.at/newpapers/pdfs/TBI-m-2010-2.pdf), the MFE was used in conjunction with accessability costs to approximate the energy of the pseudoknot-free structure. As far as I can tell, this shouldn't be necessary since `RNAPKplex` does a constrained fold anyway. Also, this change is more consistent with [the initial check](https://github.com/fncnt/ViennaRNA/blob/1ce53dc1172be0fad019e71ed7f4f7f96f6fcfbc/src/bin/RNAPKplex.c#L315). I'd be happy to get some feedback on this though.

With those changes, I was able to reproduce the [examples `HIVRT32` and `MMTV`](https://www.tbi.univie.ac.at/newpapers/pdfs/TBI-m-2010-2.pdf) but with the pseudoknot penalty removed via `-e 0.0`. The PK penalty might be another thing worth looking into.

Let me know if I missed anything important.