### PR TITLE
Allow use of arbitrary vrna_ptable in ensemble defect computation 

### DIFF
--- a/interfaces/part_func.dox
+++ b/interfaces/part_func.dox
@@ -18,10 +18,19 @@ This function is attached as method @b pf_dimer() to objects of type @em fold_co
 This function is attached as method @b mean_bp_distance() to objects of type @em fold_compound
 @endparblock
 
+@fn double vrna_ensemble_defect_pt(vrna_fold_compound_t *fc, short *pt)
+@scripting
+@parblock
+This function is attached as method @b ensemble_defect() to objects of type @em fold_compound.
+Note that the SWIG wrapper takes a structor in dot-bracket notation and an optional argument
+specifying the bracket types (default: @b VRNA_BRACKETS_RND).
+@endparblock
+
 @fn double vrna_ensemble_defect(vrna_fold_compound_t *fc, const char *structure)
 @scripting
 @parblock
-This function is attached as method @b ensemble_defect() to objects of type @em fold_compound
+This function wraps around @b vrna_ensemble_defect_pt() and is attached as method
+@b ensemble_defect() to objects of type @em fold_compound.
 @endparblock
 
 @fn double *vrna_positional_entropy(vrna_fold_compound_t *fc)

--- a/interfaces/part_func.i
+++ b/interfaces/part_func.i
@@ -115,9 +115,19 @@ char *my_pf_circ_fold(char *string, float *OUTPUT);
   }
 
   double
-  ensemble_defect(std::string structure)
+  ensemble_defect(std::string structure,
+                  unsigned int options = VRNA_BRACKETS_RND)
   {
-    return vrna_ensemble_defect($self, structure.c_str());
+    double ed;
+    short int         *pt;
+
+    pt = vrna_ptable_from_string(structure.c_str(), options);
+
+    ed = vrna_ensemble_defect_pt($self, pt);
+
+    free(pt);
+
+    return ed;
   }
 
   std::vector<double>

--- a/src/ViennaRNA/equilibrium_probs.c
+++ b/src/ViennaRNA/equilibrium_probs.c
@@ -335,21 +335,20 @@ vrna_mean_bp_distance(vrna_fold_compound_t *vc)
 
 
 PUBLIC double
-vrna_ensemble_defect(vrna_fold_compound_t *fc,
-                     const char           *structure)
+vrna_ensemble_defect_pt(vrna_fold_compound_t *fc,
+                        short                *pt)
 {
   unsigned int  i, j, n;
   int           ii;
   double        ed = -1.;
 
   if ((fc) &&
-      (structure) &&
-      (strlen(structure) == fc->length) &&
+      (pt) &&
+      (pt[0] == fc->length) &&
       (fc->exp_matrices) &&
       (fc->exp_matrices->probs)) {
     n = fc->length;
 
-    short       *pt     = vrna_ptable(structure);
     FLT_OR_DBL  *probs  = fc->exp_matrices->probs;
     int         *idx    = fc->iindx;
     ed = 0.;
@@ -375,8 +374,22 @@ vrna_ensemble_defect(vrna_fold_compound_t *fc,
 
     ed /= (double)n;
 
-    free(pt);
   }
+
+  return ed;
+}
+
+
+PUBLIC double
+vrna_ensemble_defect(vrna_fold_compound_t *fc,
+                     const char           *structure)
+{
+  double ed = -1.;
+  short *pt = vrna_ptable(structure);
+
+  ed = vrna_ensemble_defect_pt(fc, pt);
+
+  free(pt);
 
   return ed;
 }

--- a/src/ViennaRNA/equilibrium_probs.h
+++ b/src/ViennaRNA/equilibrium_probs.h
@@ -121,6 +121,33 @@ vrna_mean_bp_distance(vrna_fold_compound_t *vc);
  *  @see vrna_pf(), vrna_pairing_probs()
  *
  *  @param  fc          A fold_compound with pre-computed base pair probabilities
+ *  @param  pt          A pair table representing a target structure
+ *  @return             The ensemble defect with respect to the target structure, or -1. upon failure, e.g. pre-conditions are not met
+ */
+double
+vrna_ensemble_defect_pt(vrna_fold_compound_t *fc,
+                        short                *pt);
+
+
+/**
+ *  @brief  Compute the Ensemble Defect for a given target structure
+ *
+ *  Given a target structure @f$s@f$, compute the average dissimilarity of a randomly
+ *  drawn structure from the ensemble, i.e.:
+ *  @f[
+ *    ED(s) = 1 - \frac{1}{n} \sum_{ij, (i,j) \in s} p_{ij} - \frac{1}{n} \sum_{i}(1 - s_i)q_i
+ *  @f]
+ *  with sequence length @f$n@f$, the probability @f$p_{ij}@f$ of a base pair @f$(i,j)@f$,
+ *  the probability @f$q_i = 1 - \sum_j p_{ij}@f$ of nucleotide @f$i@f$ being unpaired, and
+ *  the indicator variable @f$s_i = 1@f$ if @f$\exists (i,j) \in s@f$, and @f$s_i = 0@f$ otherwise.
+ *
+ *  @pre  The #vrna_fold_compound_t input parameter @p fc must contain a valid base pair
+ *        probability matrix. This means that partition function and base pair probabilities
+ *        must have been computed using @p fc before execution of this function!
+ *
+ *  @see vrna_pf(), vrna_pairing_probs(), vrna_ensemble_defect_pt()
+ *
+ *  @param  fc          A fold_compound with pre-computed base pair probabilities
  *  @param  structure   A target structure in dot-bracket notation
  *  @return             The ensemble defect with respect to the target structure, or -1. upon failure, e.g. pre-conditions are not met
  */

--- a/src/ViennaRNA/equilibrium_probs.h
+++ b/src/ViennaRNA/equilibrium_probs.h
@@ -103,7 +103,7 @@ vrna_mean_bp_distance(vrna_fold_compound_t *vc);
 
 
 /**
- *  @brief  Compute the Ensemble Defect for a given target structure
+ *  @brief  Compute the Ensemble Defect for a given target structure provided as a @b vrna_ptable
  *
  *  Given a target structure @f$s@f$, compute the average dissimilarity of a randomly
  *  drawn structure from the ensemble, i.e.:
@@ -118,7 +118,7 @@ vrna_mean_bp_distance(vrna_fold_compound_t *vc);
  *        probability matrix. This means that partition function and base pair probabilities
  *        must have been computed using @p fc before execution of this function!
  *
- *  @see vrna_pf(), vrna_pairing_probs()
+ *  @see vrna_pf(), vrna_pairing_probs(), vrna_ensemble_defect()
  *
  *  @param  fc          A fold_compound with pre-computed base pair probabilities
  *  @param  pt          A pair table representing a target structure
@@ -132,6 +132,7 @@ vrna_ensemble_defect_pt(vrna_fold_compound_t *fc,
 /**
  *  @brief  Compute the Ensemble Defect for a given target structure
  *
+ *  This is a wrapper around @b vrna_ensemble_defect_pt().
  *  Given a target structure @f$s@f$, compute the average dissimilarity of a randomly
  *  drawn structure from the ensemble, i.e.:
  *  @f[

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -66,6 +66,7 @@ PERL_TESTS =  perl5/test-RNA.pl \
               perl5/test-RNA-callbacks.pl \
               perl5/test-RNA-combinatorics.pl \
               perl5/test-RNA-Design.t \
+              perl5/test-RNA-ensemble_defect.pl \
               perl5/test-RNA-file-formats.pl \
               perl5/test-RNA-mfe_eval.pl \
               perl5/test-RNA-mfe_window.pl \
@@ -105,6 +106,7 @@ PYTHON2_TESTS = python/test-RNA-combinatorics.py \
                 python/test-RNA-constraints-soft.py \
                 python/test-RNA-constraints-SHAPE.py \
                 python/test-RNA-constraints-special.py \
+                python/test-RNA-ensemble_defect.py \
                 python/test-RNA-file-formats.py \
                 python/test-RNA-mfe_eval.py \
                 python/test-RNA-mfe_window.py \
@@ -134,6 +136,7 @@ PYTHON3_TESTS = python3/test-RNA-combinatorics.py3 \
                 python3/test-RNA-constraints-soft.py3 \
                 python3/test-RNA-constraints-SHAPE.py3 \
                 python3/test-RNA-constraints-special.py3 \
+                python3/test-RNA-ensemble_defect.py3 \
                 python3/test-RNA-file-formats.py3 \
                 python3/test-RNA-mfe_eval.py3 \
                 python3/test-RNA-mfe_window.py3 \
@@ -158,6 +161,7 @@ CHECKMK_FILES = \
               energy_evaluation.ts \
               constraints.ts \
               constraints_soft.ts \
+              ensemble_defect.ts \
               fold.ts \
               utils.ts \
               eval_structure.ts \
@@ -169,6 +173,7 @@ CHECK_CFILES = \
               energy_evaluation.c \
               constraints.c \
               constraints_soft.c \
+              ensemble_defect.c \
               fold.c \
               utils.c \
               eval_structure.c \
@@ -179,6 +184,7 @@ CHECK_CFILES = \
 LIBRARY_TESTS = energy_evaluation \
                 constraints \
                 constraints_soft \
+                ensemble_defect \
                 fold \
                 utils \
                 eval_structure \

--- a/tests/ensemble_defect.ts
+++ b/tests/ensemble_defect.ts
@@ -30,8 +30,8 @@
 
   ptpk = vrna_ptable_from_string(str1, VRNA_BRACKETS_ANY);
 
-  ck_assert_double_eq(vrna_ensemble_defect(vc, str1), 0.6140797258673892);
-  ck_assert_double_eq(vrna_ensemble_defect_pt(vc, ptpk), 0.7279171755397522);
+  ck_assert(vrna_ensemble_defect(vc, str1) == 0.6140797258673892);
+  ck_assert(vrna_ensemble_defect_pt(vc, ptpk) == 0.7279171755397522);
 
   vrna_fold_compound_free(vc);
   free(ptpk);

--- a/tests/ensemble_defect.ts
+++ b/tests/ensemble_defect.ts
@@ -1,0 +1,38 @@
+#include <stdio.h>      /* printf, scanf, NULL */
+#include <stdlib.h>     /* malloc, free, rand */
+
+#include <ViennaRNA/fold_vars.h>
+#include <ViennaRNA/data_structures.h>
+#include <ViennaRNA/utils/basic.h>
+#include <ViennaRNA/utils/structures.h>
+#include <ViennaRNA/equilibrium_probs.h>
+#include <ViennaRNA/fold.h>
+#include <ViennaRNA/part_func.h>
+
+#suite Ensemble_Defect
+
+#tcase Ensemble_Defect
+
+#test test_ensemble_defect
+{
+  vrna_md_t             md;
+  vrna_fold_compound_t  *vc;
+  const char            *sequence = "AGGAAACCUUAAUUGGUUA";
+  const char  		*str1     = ".((...))(([[..))]].";
+  double ed;
+  short int *ptpk;
+
+  vrna_md_set_default(&md);
+
+  vc = vrna_fold_compound(sequence, &md, VRNA_OPTION_PF);
+
+  vrna_pf(vc, NULL);
+
+  ptpk = vrna_ptable_from_string(str1, VRNA_BRACKETS_ANY);
+
+  ck_assert_double_eq(vrna_ensemble_defect(vc, str1), 0.6140797258673892);
+  ck_assert_double_eq(vrna_ensemble_defect_pt(vc, ptpk), 0.7279171755397522);
+
+  vrna_fold_compound_free(vc);
+  free(ptpk);
+}

--- a/tests/perl5/test-RNA-ensemble_defect.pl
+++ b/tests/perl5/test-RNA-ensemble_defect.pl
@@ -1,0 +1,31 @@
+#!/usr/bin/perl -I.libs
+
+######################### We start with some black magic to print on failure.
+# (It may become useful if the test is moved to ./t subdirectory.)
+use strict;
+use Test::More tests => 2;
+use Data::Dumper;
+use FileHandle;
+
+use RNA;
+use warnings;
+
+
+######################### End of black magic.
+
+##########################################################################################################################
+#starting with ensemble_defect test
+
+my $seq     = "AGGAAACCUUAAUUGGUUA";
+my $structpk= ".((...))(([[..))]].";
+
+####################################################
+##test_ensemble_defect
+print "test_ensemble_defect\n";
+my $fc = new RNA::fold_compound($seq);
+(my $ss, my $gfe) = $fc->pf();
+my $ed = $fc->ensemble_defect($structpk);
+is($ed, 0.6140797258673892);
+$ed = $fc->ensemble_defect($structpk, RNA::BRACKETS_ANY);
+is($ed, 0.7279171755397522);
+undef $fc;

--- a/tests/python/test-RNA-ensemble_defect.py
+++ b/tests/python/test-RNA-ensemble_defect.py
@@ -1,0 +1,26 @@
+import RNApath
+
+RNApath.addSwigInterfacePath()
+
+
+import RNA
+import unittest
+
+
+seq          = "AGGAAACCUUAAUUGGUUA"
+structpk     = ".((...))(([[..))]]."
+
+class ensemble_defectTest(unittest.TestCase):
+    def test_ensemble_defect(self):
+        print "test_ensemble_defect"
+        fc = RNA.fold_compound(seq)
+        fc.pf()
+        ed = fc.ensemble_defect(structpk)
+        self.assertEqual(ed, 0.6140797258673892)
+        ed = fc.ensemble_defect(structpk, RNA.BRACKETS_ANY)
+        self.assertEqual(ed, 0.7279171755397522)
+
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/python3/test-RNA-ensemble_defect.py3
+++ b/tests/python3/test-RNA-ensemble_defect.py3
@@ -1,0 +1,25 @@
+import RNApath
+
+RNApath.addSwigInterfacePath(3)
+
+
+import RNA
+import unittest
+
+
+seq          = "AGGAAACCUUAAUUGGUUA"
+structpk     = ".((...))(([[..))]]."
+
+class ensemble_defectTest(unittest.TestCase):
+    def test_ensemble_defect(self):
+        print("test_ensemble_defect")
+        fc = RNA.fold_compound(seq)
+        fc.pf()
+        ed = fc.ensemble_defect(structpk)
+        self.assertEqual(ed, 0.6140797258673892)
+        ed = fc.ensemble_defect(structpk, RNA.BRACKETS_ANY)
+        self.assertEqual(ed, 0.7279171755397522)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Although the partition function algorithm is specific to ensembles of nested structures, the ensemble defect only relates indirectly to the ensemble type (via the partition function).
I encountered a situation were it was actually really useful to me to allow structures with pseudoknots in the calculation of the ensemble defect, so that's what this PR is about.

I tried to keep the existing API intact by introducing `vrna_ensemble_defect_pt()`, taking a `vrna_ptable` instead of a dot-bracket string. `vrna_ensemble_defect()` is just wrapped around this now.
The generated SWIG wrappers `ensemble_defect()` still take a structure string while pointing directly to the new function and take an additional parameter for the bracket types (with default value `VRNA_BRACKETS_RND` to keep the original behaviour).

I updated the corresponding documentation and added a few very simple and isolated tests to ensure I did not break the API. I hope it's clear enough to read.