### PR TITLE
Closes commands file after it is read

### DIFF
--- a/src/ViennaRNA/commands.c
+++ b/src/ViennaRNA/commands.c
@@ -290,6 +290,7 @@ vrna_file_commands_read(const char    *filename,
 
   /* cleanup */
   free(line);
+  fclose(fp);
 
   return output;
 }


### PR DESCRIPTION
Simple fix that closes the commands file after it is read into the commands data structure.  
This avoids leakage of  file descriptors. 

this fixes #171 