### PR TITLE
Fix: Python3 build failure

### DIFF
--- a/m4/ax_python3_devel.m4
+++ b/m4/ax_python3_devel.m4
@@ -64,7 +64,7 @@ AC_DEFUN([AX_PYTHON3_DEVEL],[
           AC_MSG_CHECKING([for Python3 module extension])
           dnl Usually ".so", but for example, Mac OS X uses ".dylib".
           PYTHON3_SO=`$PYTHON3 -c "import distutils.sysconfig; \
-                  print(distutils.sysconfig.get_config_vars('SO')[[0]])"`
+                  print(distutils.sysconfig.get_config_vars('EXT_SUFFIX')[[0]])"`
           AC_SUBST(PYTHON3_SO)
           AC_MSG_RESULT([$PYTHON3_SO])
 


### PR DESCRIPTION
sysconfig.get_config_var('SO') was deprecated in python 3.4, and is unset in python 3.11.0.

Causes PYTHON3_SO=None -> _RNA.so builds as "_RNANone" -> build failure:
```
ImportError: cannot import name '_RNA' from partially initialized module 'RNA'
```

See: python/cpython#60958, python/cpython#63754 and [deprecation notice here](https://github.com/python/cpython/blob/dd53b79de0ea98af6a11481217a961daef4e9774/Doc/whatsnew/3.4.rst#deprecations-in-the-python-api).