### PR TITLE
Fix: distutils related build failure in python 3.11, removal in 3.12

### DIFF
--- a/m4/ax_python3_devel.m4
+++ b/m4/ax_python3_devel.m4
@@ -8,11 +8,11 @@ AC_DEFUN([AX_PYTHON3_DEVEL],[
     AC_ARG_VAR(PYTHON3, [Path to Python3 interpreter (e.g.: /usr/bin/python3)])
 
     if test "${PYTHON3}" != "no" ; then
-      if $PYTHON3 -c 'import distutils.sysconfig' 2> /dev/null
+      if $PYTHON3 -c 'import sysconfig' 2> /dev/null
       then
         AC_MSG_CHECKING([for Python3 include path])
-        PYTHON3_INC=`$PYTHON3 -c "import distutils.sysconfig; \
-            print(distutils.sysconfig.get_python_inc())"`
+        PYTHON3_INC=`$PYTHON3 -c "import sysconfig; \
+            print(sysconfig.get_path('include'))"`
         AC_SUBST(PYTHON3_INC)
         AC_MSG_RESULT([$PYTHON3_INC])
 
@@ -37,16 +37,16 @@ AC_DEFUN([AX_PYTHON3_DEVEL],[
           AC_MSG_RESULT([$PYTHON3_LDFLAGS])
 
           AC_MSG_CHECKING([for Python3 extension linker])
-          PYTHON3_LD=`$PYTHON3 -c "import distutils.sysconfig; \
-                  print(distutils.sysconfig.get_config_var('LDSHARED'))"`
+          PYTHON3_LD=`$PYTHON3 -c "import sysconfig; \
+                  print(sysconfig.get_config_var('LDSHARED'))"`
           AC_SUBST(PYTHON3_LD)
           AC_MSG_RESULT([$PYTHON3_LD])
 
           AC_MSG_CHECKING([for directory to install Python3 scripts in])
           if test -z "$PYTHON3_DIR" ; then
             # the string concatenation below is just a trick to prevent substitution
-            PYTHON3_DIR=`$PYTHON3 -c "import distutils.sysconfig; \
-                  print(distutils.sysconfig.get_python_lib(0,0,prefix='$' '{prefix}'))"`
+            PYTHON3_DIR=`$PYTHON3 -c "import sysconfig; \
+                  print(sysconfig.get_path('purelib', vars={'base':'$' '{prefix}'}))"`
           fi
           AC_SUBST(python3dir, $PYTHON3_DIR)
           AC_MSG_RESULT([$PYTHON3_DIR])
@@ -54,8 +54,8 @@ AC_DEFUN([AX_PYTHON3_DEVEL],[
 
           AC_MSG_CHECKING([for directory to install architecture dependent python3 things in])
           if test -z "$PYTHON3_EXECDIR" ; then
-            PYTHON3_EXECDIR=`$PYTHON3 -c "import distutils.sysconfig; \
-                  print(distutils.sysconfig.get_python_lib(1,0,prefix='$' '{exec_prefix}'))"`
+            PYTHON3_EXECDIR=`$PYTHON3 -c "import sysconfig; \
+                  print(sysconfig.get_path('platlib', vars={'platbase':'$' '{exec_prefix}'}))"`
           fi
           AC_SUBST(py3execdir, $PYTHON3_EXECDIR)
           AC_MSG_RESULT([$PYTHON3_EXECDIR])
@@ -63,8 +63,8 @@ AC_DEFUN([AX_PYTHON3_DEVEL],[
 
           AC_MSG_CHECKING([for Python3 module extension])
           dnl Usually ".so", but for example, Mac OS X uses ".dylib".
-          PYTHON3_SO=`$PYTHON3 -c "import distutils.sysconfig; \
-                  print(distutils.sysconfig.get_config_vars('SO')[[0]])"`
+          PYTHON3_SO=`$PYTHON3 -c "import sysconfig; \
+                  print(sysconfig.get_config_var('EXT_SUFFIX'))"`
           AC_SUBST(PYTHON3_SO)
           AC_MSG_RESULT([$PYTHON3_SO])
 
@@ -94,10 +94,10 @@ You probably need to install python-dev, python-devel, or something similar.
       else
         AC_MSG_WARN([
 **********************************************************************
-Failed to import distutils.sysconfig!
+Failed to import sysconfig!
 **********************************************************************
 ])
-          python3_enabled_but_failed="Can't import distutils.sysconfig"
+          python3_enabled_but_failed="Can't import sysconfig"
       fi
     else
       python3_enabled_but_failed="python3 executable missing"

--- a/packaging/viennarna.spec.in
+++ b/packaging/viennarna.spec.in
@@ -78,9 +78,9 @@ BuildRequires:  python3-devel python3
 %{!?__python3: %global __python3 /usr/bin/python3}
 %endif
 
-%{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-%{!?python3_sitearch: %global python3_sitearch %(%{__python3} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
-%global python3_modext %(%{__python3} -c "from distutils.sysconfig import get_config_vars; print(get_config_vars('SO')[[0]])")
+%{!?python3_sitelib: %global python3_sitelib %(%{__python3} -c "from sysconfig import get_path; print(get_path('purelib'))")}
+%{!?python3_sitearch: %global python3_sitearch %(%{__python3} -c "from sysconfig import get_path; print(get_path('platlib'))")}
+%global python3_modext %(%{__python3} -c "from sysconfig import get_config_var; print(get_config_var('EXT_SUFFIX'))")
 
 %global __provides_exclude_from ^%{python3_sitearch}/.*\\.so$
 


### PR DESCRIPTION
distutils.sysconfig.get_config_var('SO') was deprecated in python 3.4, and is unset in python 3.11.0.

Causes PYTHON3_SO=None -> _RNA.so builds as "_RNANone" -> build failure:
```
ImportError: cannot import name '_RNA' from partially initialized module 'RNA'
```
See: python/cpython#60958, python/cpython#63754 and [deprecation notice here](https://github.com/python/cpython/blob/dd53b79de0ea98af6a11481217a961daef4e9774/Doc/whatsnew/3.4.rst#deprecations-in-the-python-api).

Also, module [distutils](https://docs.python.org/3/library/distutils.html) is deprecated and has planned removal in 3.12.
Functions get_python_inc, get_python_lib are removed, see: python/cpython#92584.