### PR TITLE
Fix missing include for size_t in constraints/soft.h

### DIFF
--- a/src/ViennaRNA/constraints/soft.h
+++ b/src/ViennaRNA/constraints/soft.h
@@ -25,6 +25,8 @@
  */
 typedef struct  vrna_sc_s vrna_sc_t;
 
+#include <stdlib.h>
+
 #include <ViennaRNA/datastructures/basic.h>
 #include <ViennaRNA/fold_compound.h>
 #include <ViennaRNA/constraints/basic.h>


### PR DESCRIPTION
This is a fix for a missing include, which turned up when parsing the ViennaRNA header files with clang to generate Julia bindings.

`.../include/ViennaRNA/constraints/soft.h:482:1: error: unknown type name 'size_t'`