### PR TITLE
Always set VRNA_WITH_JSON_SUPPORT in vrna_config.h

### DIFF
--- a/src/ViennaRNA/vrna_config.h.in
+++ b/src/ViennaRNA/vrna_config.h.in
@@ -42,8 +42,11 @@
  *
  * If this feature is present, the next line defines
  * 'VRNA_WITH_JSON_SUPPORT'
+ *
+ * Note: ViennaRNA >= 2.6.3 is always built with JSON support.
+ * This feature is still present to keep third-party code relying on it working.
  */
-@CONFIG_JSON@
+#define VRNA_WITH_JSON_SUPPORT
 
 /*
  * Build with Support Vector Machine (SVM) Z-score feature in RNALfold


### PR DESCRIPTION
Since https://github.com/ViennaRNA/ViennaRNA/commit/34a1f020d18901b5460113997b4c2fcefc8e95c4, JSON support is always enabled but the corresponding macro `VRNA_WITH_JSON_SUPPORT` is not substituted in `vrna_config.h.in` anymore: 
 https://github.com/ViennaRNA/ViennaRNA/blob/18c8556721ebcd537cf57383a1d8f82ee7829198/src/ViennaRNA/vrna_config.h.in#L46
 
I decided to simply hardcode this feature instead of removing these lines, in case any downstream code relies on having this macro defined.
I'm happy to modify as needed though.