### PR TITLE
fix: Allow custom alphabet folding

### DIFF
--- a/src/bin/RNAsubopt.ggo
+++ b/src/bin/RNAsubopt.ggo
@@ -462,7 +462,7 @@ hidden
 option  "energyModel" -
 "Set energy model.\n"
 details="Rarely used option to fold sequences from the artificial ABCD... alphabet, where\
- A pairs B, C-D etc.  Use the energy parameters for GC (-e 1) or AU (-e 2) pairs.\n\n"
+ A pairs B, C-D etc.  Use the energy parameters for GC (--energyModel 1) or AU (--energyModel 2) pairs.\n\n"
 int
 optional
 hidden

--- a/src/bin/gengetopt_helpers.h
+++ b/src/bin/gengetopt_helpers.h
@@ -183,7 +183,10 @@ set_salt_DNA(vrna_md_t *md);
     /* salt correction support */ \
     ggo_get_salt(ggostruct, md.salt); \
     /* set energy model */ \
-    ggo_get_energyModel(ggostruct, md.energy_set); \
+    { ggo_get_energyModel(ggostruct, md.energy_set); \
+      if(md.energy_set > 0) \
+        vrna_md_update(&md); \
+    } \
     /* Allow other pairs in addition to the usual AU,GC,and GU pairs */ \
     { char *ns_bases = NULL; \
       ggo_get_nsp(ggostruct, ns_bases); \


### PR DESCRIPTION
## Summary

Programs like `RNAfold` and `RNAsubopt` have the option `--energyModel`, which doesn't work as expected.

## Implementation notes

After parsing the command line options, `vrna_md_update` must be called if a non-default energy model is set. 

## Testing

Pre-fix behaviour:
````bash
> RNAfold --energyModel=1 <<< "AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD"
AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD
((((((...((((((...))))))...)))))) (-14.20)

> RNAfold --energyModel=2 <<< "AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD"
AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD
((((((...((((((...))))))...)))))) (-14.20)

> RNAfold --energyModel=3 <<< "AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD"
AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD
((((((...((((((...))))))...)))))) (-14.20)
````

Post-fix behaviour:
````bash
> RNAfold --energyModel=1 <<< "AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD"
AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD
((((((...))))))...((((((...)))))) (-29.60)

> RNAfold --energyModel=2 <<< "AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD"
AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD
((((((...))))))...((((((...)))))) ( -0.80)

> RNAfold --energyModel=3 <<< "AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD"
AAAAAACCCBBBBBBDDDCCCCCCAAADDDDDD
((((((...))))))...((((((...)))))) (-14.90)
````

## Additional notes

Since `-e` in `RNAsubopt` is used for `--deltaEnergy`, the example usages in the help message for `--energyModel` were fixed.