### PR TITLE
Fix wrong delta G binding in RNAcofold 

### DIFF
--- a/src/ViennaRNA/partfunc/partfunc.c
+++ b/src/ViennaRNA/partfunc/partfunc.c
@@ -1239,7 +1239,7 @@ extract_dimer_props(vrna_fold_compound_t  *fc,
 
     *FAB  = -kT * (log(QToT) + n * log(params->pf_scale));
     *F0AB = -kT * (log(Qzero) + n * log(params->pf_scale));
-    *FcAB = (QAB > 1e-17) ? -kT * (log(QAB) + n * log(params->pf_scale)) : 999;
+    *FcAB = (QAB > DBL_MIN) ? -kT * (log(QAB) + n * log(params->pf_scale)) : 999;
     *FA   = -kT *
             (log(matrices->q[fc->iindx[1] - se[so[0]]]) + (se[so[0]]) *
              log(params->pf_scale));

--- a/src/bin/RNAcofold.c
+++ b/src/bin/RNAcofold.c
@@ -959,6 +959,11 @@ process_record(struct record_data *record)
     /* compute partition function */
     AB = AA = BB = vrna_pf_dimer(vc, pairing_propensity);
 
+    if(AB.FcAB == 999) {
+      vrna_log_error("underflow in calculating the free energy of connected ensamble FcAB\n"
+        "use smaller pf_scale");
+    }
+
     if (opt->md.compute_bpp) {
       char *costruc = NULL;
       prAB = vrna_plist_from_probs(vc, opt->bppmThreshold);


### PR DESCRIPTION
## Summary

For longer, particularly stable pairs of sequences, `RNAcofold` returns wrong $\Delta_{\rm bind}G$ without an error message.

## Implementation notes

The wrong result stems from the following underflow check https://github.com/ViennaRNA/ViennaRNA/blob/219394580aec203a9d6f0d5450021e22642d5a83/src/ViennaRNA/partfunc/partfunc.c#L1242

I believe the threshold value could be chosen significantly smaller, for example `DBL_MIN`. Additionally, an error message should be issued in `RNAcofold` when an underflow occurs nevertheless.

## Testing

Pre-fix behaviour:
```bash
> RNAcofold -p <<< "CCGGCCGGCCCGGCCCGGCGCCGGGGCCCCGGGGCGCCGCGGCGCCCGCCGCGGCGCGCCCCGGGCGCGCCGGCUGGCGGGGCCGCGGCGCGCGGGGGCCCGCCGGGCGCCGGCCCGGGGGCGCCGGCGGGGCGGGCCGGGCCCCCGGCCGGCGGGCGGCCGGGGGGGCGCCUGCGGCCCGGCGCCGCCGGGCCGGGCGG & CCGGCCGGCCCGGCCCGGCGCCGGGGCCCCGGGGCGCCGCGGCGCCCGCCGCGGCGCGCCCCGGGCGCGCCGGCUGGCGGGGCCGCGGCGCGCGGGGGCCCGCCGGGCGCCGGCCCGGGGGCGCCGGCGGGGCGGGCCGGGCCCCCGGCCGGCGGGCGGCCGGGGGGGCGCCUGCGGCCCGGCGCCGCCGGGCCGGGCGG"

(((.((((((((((..((((((((((((((.(.((((((((((.(((((((((((((((((.((((((((((.(.((((((((((((((((.(.((((((((((...((((((((.((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))(((((((((((((((((.(((.&.))).))))))))))..)))))))))))))).).)))))))))).))))))))))))))))).))))))))).)).)))))))))))))))).).)))))))(((...((((((((.((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))))))))))))))))))).))) (-410.70)
(((.((((((((((..((((((((((((((.(.((((((((((.(((((((((((((((((.((((((((({.{.((((((((((((((((.(.((((((((((...(((((({{{((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))(((((((((((((((((.(((.&.))).))))))))))..)))))))))))))).).)))))))))).))))))))))))))))).)))))))))).}.)))))))))))))))).).)))))))(((...(((((({{{((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))))))))))))))))))).))) [-414.22]
 frequency of mfe structure in ensemble 0.00331995; delta G binding=1400.42
```
Post-fix behaviour:

```bash
> RNAcofold -p <<< "CCGGCCGGCCCGGCCCGGCGCCGGGGCCCCGGGGCGCCGCGGCGCCCGCCGCGGCGCGCCCCGGGCGCGCCGGCUGGCGGGGCCGCGGCGCGCGGGGGCCCGCCGGGCGCCGGCCCGGGGGCGCCGGCGGGGCGGGCCGGGCCCCCGGCCGGCGGGCGGCCGGGGGGGCGCCUGCGGCCCGGCGCCGCCGGGCCGGGCGG & CCGGCCGGCCCGGCCCGGCGCCGGGGCCCCGGGGCGCCGCGGCGCCCGCCGCGGCGCGCCCCGGGCGCGCCGGCUGGCGGGGCCGCGGCGCGCGGGGGCCCGCCGGGCGCCGGCCCGGGGGCGCCGGCGGGGCGGGCCGGGCCCCCGGCCGGCGGGCGGCCGGGGGGGCGCCUGCGGCCCGGCGCCGCCGGGCCGGGCGG"

(((.((((((((((..((((((((((((((.(.((((((((((.(((((((((((((((((.((((((((((.(.((((((((((((((((.(.((((((((((...((((((((.((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))(((((((((((((((((.(((.&.))).))))))))))..)))))))))))))).).)))))))))).))))))))))))))))).))))))))).)).)))))))))))))))).).)))))))(((...((((((((.((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))))))))))))))))))).))) (-410.70)
(((.((((((((((..((((((((((((((.(.((((((((((.(((((((((((((((((.((((((((({.{.((((((((((((((((.(.((((((((((...(((((({{{((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))(((((((((((((((((.(((.&.))).))))))))))..)))))))))))))).).)))))))))).))))))))))))))))).)))))))))).}.)))))))))))))))).).)))))))(((...(((((({{{((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))))))))))))))))))).))) [-414.22]
 frequency of mfe structure in ensemble 0.00331995; delta G binding=-12.80
```

This matches the expected result from current version with smaller `pfScale`:
```bash
> RNAcofold -p --pfScale=1.05 <<< "CCGGCCGGCCCGGCCCGGCGCCGGGGCCCCGGGGCGCCGCGGCGCCCGCCGCGGCGCGCCCCGGGCGCGCCGGCUGGCGGGGCCGCGGCGCGCGGGGGCCCGCCGGGCGCCGGCCCGGGGGCGCCGGCGGGGCGGGCCGGGCCCCCGGCCGGCGGGCGGCCGGGGGGGCGCCUGCGGCCCGGCGCCGCCGGGCCGGGCGG & CGGCCGGCCCGGCCCGGCGCCGGGGCCCCGGGGCGCCGCGGCGCCCGCCGCGGCGCGCCCCGGGCGCGCCGGCUGGCGGGGCCGCGGCGCGCGGGGGCCCGCCGGGCGCCGGCCCGGGGGCGCCGGCGGGGCGGGCCGGGCCCCCGGCCGGCGGGCGGCCGGGGGGGCGCCUGCGGCCCGGCGCCGCCGGGCCGGGCGG"

(((.((((((((((..((((((((((((((.(.((((((((((.(((((((((((((((((.((((((((((.(.((((((((((((((((.(.((((((((((...((((((((.((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))(((((((((((((((((.(((.&.))).))))))))))..)))))))))))))).).)))))))))).))))))))))))))))).))))))))).)).)))))))))))))))).).)))))))(((...((((((((.((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))))))))))))))))))).))) (-410.70)
(((.((((((((((..((((((((((((((.(.((((((((((.(((((((((((((((((.((((((((({.{.((((((((((((((((.(.((((((((((...(((((({{{((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))(((((((((((((((((.(((.&.))).))))))))))..)))))))))))))).).)))))))))).))))))))))))))))).)))))))))).}.)))))))))))))))).).)))))))(((...(((((({{{((((((.(((((.......))))))))))))))))))))))(((((.(((....))).)))))))))))))))))))))).))) [-414.22]
 frequency of mfe structure in ensemble 0.00331995; delta G binding=-12.80
```

## Additional notes

I have added an error message only to `RNAcofold.c`, but there might be some other parts of code calling `vrna_pf_dimer` which would also need it.