### PR TITLE
.github: give python2 to the workflows that need them

### DIFF
--- a/.github/workflows/dist_archives.yaml
+++ b/.github/workflows/dist_archives.yaml
@@ -63,12 +63,11 @@ jobs:
           help2man \
           bison \
           flex \
+          libnsl2 \
           libtool \
           check \
           liblapacke \
           liblapacke-dev \
-          python2 \
-          python2-dev \
           graphviz \
           python3-sphinx \
           python3-myst-parser \
@@ -79,6 +78,15 @@ jobs:
           texlive-latex-extra \
           texlive-font-utils \
           texlive-fonts-recommended
+    - name: Install Python2 from 22.04
+      run:  |
+        wget 'https://archive.ubuntu.com/ubuntu/pool/universe/p/python2.7/?C=M;O=D' -O py27.html
+        VERSION=$(grep -v '20.04' py27.html | grep -o -- '_2\.7\.18[^<>]\+\_'$(dpkg --print-architecture)'.deb' | head -n 1)
+        for i in {libpython2.7-stdlib,{lib,}python2.7{,-dev,-minimal}}; do
+          wget "https://archive.ubuntu.com/ubuntu/pool/universe/p/python2.7/${i}${VERSION}" &
+        done
+        wait
+        sudo dpkg -R --install .
     - name: Autotools setup
       run:  |
         tar -xjf src/dlib-19.24.tar.bz2 -C src

--- a/.github/workflows/dist_check.yaml
+++ b/.github/workflows/dist_check.yaml
@@ -36,12 +36,11 @@ jobs:
           help2man \
           bison \
           flex \
+          libnsl2 \
           libtool \
           check \
           liblapacke \
           liblapacke-dev \
-          python2 \
-          python2-dev \
           graphviz \
           python3-sphinx \
           python3-myst-parser \
@@ -52,6 +51,15 @@ jobs:
           texlive-latex-extra \
           texlive-font-utils \
           texlive-fonts-recommended
+    - name: Install Python2 from 22.04
+      run:  |
+        wget 'https://archive.ubuntu.com/ubuntu/pool/universe/p/python2.7/?C=M;O=D' -O py27.html
+        VERSION=$(grep -v '20.04' py27.html | grep -o -- '_2\.7\.18[^<>]\+\_'$(dpkg --print-architecture)'.deb' | head -n 1)
+        for i in {libpython2.7-stdlib,{lib,}python2.7{,-dev,-minimal}}; do
+          wget "https://archive.ubuntu.com/ubuntu/pool/universe/p/python2.7/${i}${VERSION}" &
+        done
+        wait
+        sudo dpkg -R --install .
     - name: Autotools setup
       run:  |
         tar -xjf src/dlib-19.24.tar.bz2 -C src


### PR DESCRIPTION
... by taking from 22.04. Yes they are binary compatible.. No this is not a good idea, but it is the best one I can come up with.

I decided to use the faster "pool" link and protect against future versions by reading the list of versions from the pool index.html using grep.

Other ideas include:
* Build it yourself: Takes too long, needs to set up CI cache to make time tolerable
* Download from elsewhere: will have a different path and introduce additional variables, also more people to trust

This should stay functional until 22.04 gets purged out of the pool. That would be no earlier than June 2027 based on the support schedule, but we should still have like 5 years more because they do not purge a distro out of the pool right after it is out of support. Bionic (18.04) went EOL in June 2023 but it is still in the pool today, 2025-06-25!

This fixes #267 and should make the PRs become green.